### PR TITLE
Fix typo in german translation

### DIFF
--- a/content/de/more/06-01-li-and-is.mdx
+++ b/content/de/more/06-01-li-and-is.mdx
@@ -58,7 +58,7 @@ Nein! "*Ist das ein Verb oder ein Nomen/Adjektiv?*" und "*Ist das eine Aussage o
 <List>
   <Word sl="jan li lukin." m="Die Person sieht.<br />Aussage → 󱤧 li. Verb → kein 'sein'." />
   <Word sl="jan li pona." m="Die Person ist gut.<br />Aussage → 󱤧 li. Adjektiv → braucht 'sein'." />
-  <Word sl="jan o moku!" m="Person, sieh!<br />Kommando → 󱥄 o. Verb → kein 'sein'." />
+  <Word sl="jan o moku!" m="Person, iss!<br />Kommando → 󱥄 o. Verb → kein 'sein'." />
   <Word sl="jan o pona!" m="Person, sei gut!<br />Kommando → 󱥄 o. Verb → braucht 'sein'." />
 </List>
 


### PR DESCRIPTION
There was typo in the german translation for jan o moku. It said "sieh" which means "watch" and not "iss" which is the german imperative form of "eat"