### PR TITLE
Fix Japanese translation for "vowels"

### DIFF
--- a/content/jp/locale.json
+++ b/content/jp/locale.json
@@ -9,7 +9,7 @@
   "Coronal": "舌頂",
   "Dorsal": "舌背",
 
-  "Vowels": "子音",
+  "Vowels": "母音",
   "Front": "前舌",
   "Central": "中舌",
   "Back": "後舌",


### PR DESCRIPTION
The current translation has 子音 for both "consonants" and "vowels"